### PR TITLE
Support non-matching fastq file names

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -102,7 +102,7 @@ ch_output_docs = Channel.fromPath("$baseDir/docs/output.md")
 if(params.readPaths){
     Channel
         .from(params.readPaths)
-        .map { row -> [row[0], [file(row[1][0]), file(row[2][0])]] }
+        .map { row -> [row[0], [file(row[1][0]), file(row[1][1])]] }
         .ifEmpty { exit 1, "params.readPaths was empty - no input files supplied" }
         .set { read_files }
 

--- a/main.nf
+++ b/main.nf
@@ -102,7 +102,7 @@ ch_output_docs = Channel.fromPath("$baseDir/docs/output.md")
 if(params.readPaths){
     Channel
         .from(params.readPaths)
-        .map { row -> [ row[0], [file(row[1][0])]] }
+        .map { row -> [row[0], [file(row[1][0]), file(row[2][0])]] }
         .ifEmpty { exit 1, "params.readPaths was empty - no input files supplied" }
         .set { read_files }
 

--- a/main.nf
+++ b/main.nf
@@ -116,7 +116,7 @@ if(params.readPaths){
 // Get the pre-Lane sample name and R1 match
 def pattern = ~/([\w-]+)_L(\d+)/
 read_files
-  .map { name, reads -> tuple((name =~ sample_name_pattern).iterator().collect().getAt(0)?.getAt(1) ?: name, reads) }
+  .map { name, reads -> tuple((name =~ pattern).iterator().collect().getAt(0)?.getAt(1) ?: name, reads) }
   .groupTuple()
   .map { name, reads -> tuple(name, reads.transpose()) }
   .flatMap { name, reads -> reads.indexed().collect { index, item -> tuple(name, "R${index + 1}", item) } }


### PR DESCRIPTION
- Use less regex and more functional programming to map read filenames
- Allow files that don't match the lane regex to simply pass through (while still maintaining correctness, e.g. read number)

Not sure if the changes I made work for the test?

Many thanks to contributing to nf-core/fastqcat!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/fastqcat branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/fastqcat)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/fastqcat/tree/master/.github/CONTRIBUTING.md